### PR TITLE
Add arm64 image build as it is more efficient and cost effective

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,14 @@
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.x
       - run: make lint
@@ -17,30 +17,33 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     needs: test
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - name: Create GitHub release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           body: TODO
           draft: true
 
   assets:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, linux/arm64]
     runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: write
     needs: release
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.x
       - run: echo "APP_VERSION=$(git describe --tags --abbrev=0 | sed -e 's/^v//')" >> $GITHUB_ENV
@@ -50,14 +53,13 @@ jobs:
       - run: echo "ASSET_PATH=dist/v${{ env.APP_VERSION }}/${{ env.ASSET_NAME }}" >> $GITHUB_ENV
         shell: bash
       - run: make dist
-      - uses: actions/upload-release-asset@v1
+      - uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET_PATH }}
-          asset_name: ${{ env.ASSET_NAME }}
-          asset_content_type: application/gzip
+            tag_name: ${{ github.ref }}
+            files: |
+              dist/v${{ env.APP_VERSION }}/${{ env.ASSET_NAME }}/*
 
   docker:
     runs-on: ubuntu-latest
@@ -66,23 +68,23 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/login-action@v1
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v3
+      - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/fastly/fastly-exporter
+          images: ghcr.io/alphagov/fastly-exporter
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern=v{{major}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{version}}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
Add option to manually trigger image build
Update GHCR to use alphagov
Remove windows-latest as it's failing tests
Use softprops action-gh-release as actions/action-release is deprecated
Add contents write permission and remove release_name
Use softprops/action-gh-release to upload assets
Set tag_name in ci.yaml to appease tag check by gh release action
Add write permissions for assets in ci.yaml
Bump up versions in ci.yaml